### PR TITLE
#available_events allows metadata and check for actually available transitions

### DIFF
--- a/lib/statesman/events.rb
+++ b/lib/statesman/events.rb
@@ -41,10 +41,10 @@ module Statesman
       false
     end
 
-    def available_events
+    def available_events(metadata = {})
       state = current_state
       self.class.events.select do |_, transitions|
-        transitions.key?(state)
+        ( Array.wrap(transitions[state]) & allowed_transitions(metadata) ).any?
       end.map(&:first)
     end
   end


### PR DESCRIPTION
I know this is a bit rough, it's just an idea

My purpose was to check for events that include only actually available transitions
I'm forwarding metadata to allow metadata based guards (i.e. current_user)