### PR TITLE
Statesman 5 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ failure.
 instance.trigger!(:some_event)
 ```
 Triggers the passed event, returning `true` on success. Raises
-`Statesman::GuardFailedError` or `Statesman::TransitionFailedError` on failure.
+`Statesman::GuardFailedError` or `Statesman::InvalidTransitionError` on failure.
 
 #### `Event#available_events`
 ```ruby

--- a/lib/statesman/events.rb
+++ b/lib/statesman/events.rb
@@ -22,12 +22,12 @@ module Statesman
 
     def trigger!(event_name, metadata = {})
       transitions = self.class.events.fetch(event_name) do
-        raise Statesman::TransitionFailedError,
+        raise Statesman::InvalidTransitionError,
               "Event #{event_name} not found"
       end
 
       new_state = transitions.fetch(current_state) do
-        raise Statesman::TransitionFailedError,
+        raise Statesman::InvalidTransitionError,
               "State #{current_state} not found for Event #{event_name}"
       end
 
@@ -37,7 +37,7 @@ module Statesman
 
     def trigger(event_name, metadata = {})
       self.trigger!(event_name, metadata)
-    rescue Statesman::TransitionFailedError, Statesman::GuardFailedError
+    rescue Statesman::InvalidTransitionError, Statesman::GuardFailedError
       false
     end
 

--- a/spec/statesman/events_spec.rb
+++ b/spec/statesman/events_spec.rb
@@ -65,7 +65,7 @@ describe Statesman::Events do
     context "when the state cannot be transitioned to" do
       it "raises an error" do
         expect { instance.trigger!(:event_2) }.
-          to raise_error(Statesman::TransitionFailedError)
+          to raise_error(Statesman::InvalidTransitionError)
       end
     end
 


### PR DESCRIPTION
https://github.com/gocardless/statesman/commit/c672e7bb6b65c3423dff22e10c9b82a305336cff broke `statesman-events` compatiblity. 

Using `Statesman::InvalidTransitionError` instead of `Statesman::TransitionFailedError` seemed like a reasonable fix.

Fixes #4.